### PR TITLE
Version 1.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.exe
 *.splm
 /.vscode
+/build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "splimer"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "splimer"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ splimer
     --quiet                                 Quiet mode, removes all console output
                                             (if program exited right)
 
+    --backslash-delimiter           Replaces backslashes to forward slashes in file names to write doing merge
+                                    Use it if 
+                                    * directory was splitted on Windows
+                                    * with splimer version 1.2.0 or lower
+                                    * and you want to merge it on Linux or macOS
 
     -h 
     --help                                  Show help message

--- a/build.py
+++ b/build.py
@@ -1,0 +1,28 @@
+import re
+import os
+
+ver = re.search(r'\[package\]\nname = "splimer"\nversion = "(.+)"', open("Cargo.toml").read()).group(1)
+commands = [
+    ("cargo build --release --target x86_64-pc-windows-msvc",       'win10', 'x86', '64'),
+    ("cargo zigbuild --release --target x86_64-unknown-linux-gnu",  'linux', 'x86', '64'),
+    ("cargo zigbuild --release --target x86_64-apple-darwin",       'macos', 'x86', '64'),
+    ("cargo build --release --target i686-pc-windows-msvc",         'win10', 'x86', '32'),
+    ("cargo zigbuild --release --target i686-unknown-linux-gnu",    'linux', 'x86', '32'),
+    ("cargo zigbuild --release --target aarch64-unknown-linux-gnu", 'linux', 'arm', '64'),
+    ("cargo zigbuild --release --target aarch64-apple-darwin",      'macos', 'arm', '64'),
+    ("cargo zigbuild --release --target aarch64-pc-windows-gnullvm", 'win10', 'arm', '64'),
+]
+
+for com, system, arch, bit in commands:
+    print("$", com)
+    os.system(com)
+
+    target_name = com.split()[-1]
+    
+    if not os.path.exists('build'):
+        os.mkdir("build")
+    
+    os.replace(
+        f"./target/{target_name}/release/splimer{'.exe' if 'windows' in target_name else ''}",
+        f"./build/splimer_v{ver}_{system}_{arch}_{bit}{'.exe' if 'windows' in target_name else ''}",
+    )

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,12 @@ splimer
     --quiet                                 Quiet mode, removes all console output
                                             (if program exited right)
 
+    --backslash-delimiter           Replaces backslashes to forward slashes in file names to write doing merge
+                                    Use it if 
+                                    * directory was splitted on Windows
+                                    * with splimer version 1.2.0 or lower
+                                    * and you want to merge it on Linux or macOS
+
     -h 
     --help                                  Show help message"
             );

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -60,7 +60,8 @@ pub struct ProgramInput {
     pub output_directory: Option<String>,
     pub parts: Option<usize>,
     pub part_number: Option<usize>,
-    pub is_quiet: bool
+    pub is_quiet: bool,
+    pub backslash_delimiter: bool,
 }
 
 struct ProgramInputBuilder {
@@ -70,7 +71,8 @@ struct ProgramInputBuilder {
     pub output_directory: Option<String>,
     pub parts: Option<usize>,
     pub part_number: Option<usize>,
-    pub is_quiet: bool
+    pub is_quiet: bool,
+    pub backslash_delimiter: bool,
 }
 
 impl ProgramInputBuilder {
@@ -82,7 +84,8 @@ impl ProgramInputBuilder {
             output_directory: None,
             parts: None,
             part_number: None,
-            is_quiet: false
+            is_quiet: false,
+            backslash_delimiter: false,
         }
     }
 }
@@ -156,7 +159,8 @@ impl ProgramInput {
                 output_directory: builder.output_directory.clone(),
                 parts: builder.parts,
                 part_number: builder.part_number,
-                is_quiet: builder.is_quiet
+                is_quiet: builder.is_quiet,
+                backslash_delimiter: builder.backslash_delimiter
             }
         );
     }
@@ -221,6 +225,10 @@ impl ProgramInput {
             },
             "-q" | "--quiet" => {
                 builder.is_quiet = true;
+                return ParseResult::SuccessfulHandledFlag;
+            },
+            "--backslash-delimiter" => {
+                builder.backslash_delimiter = true;
                 return ParseResult::SuccessfulHandledFlag;
             },
             "-h" | "--help" => {

--- a/src/splimer.rs
+++ b/src/splimer.rs
@@ -577,6 +577,12 @@ impl Splimer {
         let reader = BufReader::new(file);
         self.records = serde_json::from_reader(reader).expect("Directory file is corrupted and cannot be read!");
 
+        if self.program_input.backslash_delimiter {
+            for rec in &mut self.records {
+                rec.path = rec.path.replace("\\", "/");
+            }
+        }
+
         Ok(())
     }
 

--- a/src/splimer.rs
+++ b/src/splimer.rs
@@ -4,7 +4,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{BufReader, Read, Seek, SeekFrom, Write};
 use std::io;
 use regex::Regex;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use serde::{Serialize, Deserialize};
 use serde_json;
@@ -46,9 +46,9 @@ impl Splimer {
         
         for (path, size) in files {            
             let relative_path = path.strip_prefix(&root_path)
-                .unwrap_or(&path)
-                .to_string_lossy()
-                .into_owned();
+                .unwrap_or(&path);
+
+            let relative_path = to_unix_path(relative_path);
             
             self.records.push(FileRecord {
                 path: relative_path,
@@ -580,4 +580,39 @@ impl Splimer {
         Ok(())
     }
 
+}
+
+fn to_unix_path(path: &Path) -> String {
+    let mut components = path.components();
+    let mut unix_path = String::new();
+
+    while let Some(component) = components.next() {
+        match component {
+            Component::Prefix(prefix) => {
+                if let Some(disk) = prefix.as_os_str().to_str().and_then(|s| s.strip_suffix(':')) {
+                    unix_path.push_str(&disk.to_lowercase());
+                    unix_path.push_str("/");
+                }
+            }
+            Component::RootDir => {
+                unix_path.push('/');
+            }
+            Component::CurDir => {
+                unix_path.push_str("./");
+            }
+            Component::ParentDir => {
+                unix_path.push_str("../");
+            }
+            Component::Normal(name) => {
+                if let Some(name_str) = name.to_str() {
+                    unix_path.push_str(name_str);
+                }
+                if components.as_path() != Path::new("") {
+                    unix_path.push('/');
+                }
+            }
+        }
+    }
+
+    unix_path
 }


### PR DESCRIPTION
This PR:
* fixes bug when directory was splitted on Windows, file paths was stored with backslashes resulting in extracting wrong file structure on Linux and macOS
* features `--backslash-delimiter` to fix merging directory, which was splitted with splimer 1.2.0 or lower